### PR TITLE
edit repository link

### DIFF
--- a/plan9port/man/man1/git.html
+++ b/plan9port/man/man1/git.html
@@ -21,7 +21,7 @@
 
 <table border=0 cellpadding=0 cellspacing=0><tr height=2><td><tr><td width=20><td>
 
-    <tt><font size=+1>git clone https://9fans.github.io/plan9port plan9 
+    <tt><font size=+1>git clone https://github.com/9fans/plan9port plan9 
     <table border=0 cellpadding=0 cellspacing=0><tr height=5><td></table>
     </font></tt>
     <tt><font size=+1>git pull 


### PR DESCRIPTION
No repository at https://9fans.github.io/plan9port. An attempt to clone using this link:
```
$ git clone https://9fans.github.io/plan9port plan9
Cloning into 'plan9'...
fatal: repository 'https://9fans.github.io/plan9port/' not found
```