### PR TITLE
Modify Install Instructions to inform user that libfontconfig1-dev is required.

### DIFF
--- a/plan9port/man/man1/install.1
+++ b/plan9port/man/man1/install.1
@@ -101,7 +101,7 @@ with single quotes.
 .PP
 On most Linux systems, the X11 header packages need to be installed
 to build using X11.  On Debian. the required packages are
-libx11-dev, libxext-dev, and libxt-dev.
+libx11-dev, libxext-dev, libfontconfig1-dev, and libxt-dev.
 On Ubuntu, it suffices to install xorg-dev.
 .PP
 .I INSTALL

--- a/plan9port/man/man1/install.html
+++ b/plan9port/man/man1/install.html
@@ -78,7 +78,7 @@
     
     On most Linux systems, the X11 header packages need to be installed
     to build using X11. On Debian. the required packages are libx11-dev,
-    libxext-dev, and libxt-dev. On Ubuntu, it suffices to install
+    libxext-dev, libfontconfig1-dev, and libxt-dev. On Ubuntu, it suffices to install
     xorg-dev. 
     <table border=0 cellpadding=0 cellspacing=0><tr height=5><td></table>
     


### PR DESCRIPTION
On Debian testing/sid when trying to run ./INSTALL it failed with:
```
x11.c:3:10: fatal error: fontconfig/fontconfig.h: No such file or directory
3 | #include <fontconfig/fontconfig.h>
| ^~~~~~~~~~~~~~~~~~~~~~~~~
```

And by using Sudo apt install libfontconfig1-dev fix this issule.

Fixes #4